### PR TITLE
[!!!][TASK] Fix and streamline composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,17 +1,21 @@
 {
-  "name": "Bitmotion/SecureDownloads",
+  "name": "bitmotion/secure-downloads",
   "type": "typo3-cms-extension",
   "description": "\"Secure Download\": Apply TYPO3 access rights to ALL file assets (PDFs, TGZs or JPGs etc. - configurable) - protect them from direct access.",
   "license": [
     "GPL-2.0+"
   ],
   "require": {
-    "typo3/cms-core": ">=6.2.0,<8.9.99"
+    "typo3/cms-core": "^6.2.12 || ^7.6 || ^8.0"
   },
   "autoload": {
     "psr-4": {
       "Bitmotion\\SecureDownloads": "Classes"
     }
+  },
+  "replace": {
+    "secure_downloads": "self.version",
+    "typo3-ter/secure-downloads": "self.version"
   }
 }
 


### PR DESCRIPTION
Composer names do not support casing, thus we choose a more reasonable name.

Besides that, we add a replace section to make it possible to install the
extension via composer.

Also make TYPO3 dependencies much clearer.