### PR TITLE
[BUGFIX] HtmlParser ist not absRefPrefix aware

### DIFF
--- a/Classes/Parser/HtmlParser.php
+++ b/Classes/Parser/HtmlParser.php
@@ -196,7 +196,15 @@ class HtmlParser
     protected function parseTag($tag)
     {
         if (preg_match($this->tagPattern, $tag, $matchedUrls)) {
-            $replace = $this->delegate->publishResourceUri($matchedUrls[1]);
+            $resourceUri = $matchedUrls[1];
+            $containsAbsRefPrefix = \TYPO3\CMS\Core\Utility\GeneralUtility::isFirstPartOfStr($matchedUrls[1], $GLOBALS['TSFE']->absRefPrefix);
+            if ($containsAbsRefPrefix) {
+                $resourceUri = substr($resourceUri, strlen($GLOBALS['TSFE']->absRefPrefix));
+            }
+            $replace = $this->delegate->publishResourceUri($resourceUri);
+            if ($containsAbsRefPrefix) {
+                $replace = $GLOBALS['TSFE']->absRefPrefix . $replace;
+            }
             $tagexp = explode($matchedUrls[1], $tag, 2);
             $tag = $this->recursion($tagexp[0] . $replace, $tagexp[1]);
 


### PR DESCRIPTION
Currently absRefPrefix handling is missing in the HtmlParser. Although this change isn't very pretty, it shows how to solve the problem.