### PR TITLE
Basic v9 compatibility

### DIFF
--- a/Classes/Controller/LogController.php
+++ b/Classes/Controller/LogController.php
@@ -34,6 +34,7 @@ use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\PathUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Mvc\View\ViewInterface;
 use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
@@ -221,7 +222,7 @@ class LogController extends ActionController
 
         /** @var PageRenderer $pageRenderer */
         $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
-        $pageRenderer->addCssFile(ExtensionManagementUtility::extRelPath('secure_downloads') . 'Resources/Public/Styles/Styles.css');
+        $pageRenderer->addCssFile(PathUtility::getRelativePathTo(ExtensionManagementUtility::extPath('secure_downloads')) . 'Resources/Public/Styles/Styles.css');
         $this->createMenu();
     }
 

--- a/Classes/Resource/FileDelivery.php
+++ b/Classes/Resource/FileDelivery.php
@@ -564,7 +564,7 @@ class FileDelivery
                 list($strAdditionalFileExtension, $strAdditionalMimeType) = GeneralUtility::trimExplode('|',
                     $strAdditionalMimeTypeItem);
                 if (!empty($strAdditionalFileExtension) && !empty($strAdditionalMimeType)) {
-                    $strAdditionalFileExtension = GeneralUtility::strtolower($strAdditionalFileExtension);
+                    $strAdditionalFileExtension = mb_strtolower($strAdditionalFileExtension, 'utf-8');
                     $arrMimeTypes[$strAdditionalFileExtension] = $strAdditionalMimeType;
                 }
             }
@@ -611,7 +611,7 @@ class FileDelivery
      */
     protected function getFileExtensionByFilename($strFileName)
     {
-        return GeneralUtility::strtolower(ltrim(strrchr($strFileName, '.'), '.'));
+        return mb_strtolower(ltrim(strrchr($strFileName, '.'), '.'), 'utf-8');
     }
 
     /**

--- a/Classes/Resource/Publishing/PhpDeliveryProtectedResourcePublishingTarget.php
+++ b/Classes/Resource/Publishing/PhpDeliveryProtectedResourcePublishingTarget.php
@@ -108,7 +108,7 @@ class PhpDeliveryProtectedResourcePublishingTarget extends AbstractResourcePubli
         $replacements = [
             $userId,
             rawurlencode(implode(',', $userGroupIds)),
-            GeneralUtility::rawUrlEncodeFP($resourceUri),
+            str_replace('%2F', '/', rawurlencode($resourceUri)),
             $validityPeriod,
             $hash,
             $GLOBALS['TSFE']->id,

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "GPL-2.0+"
   ],
   "require": {
-    "typo3/cms-core": "^7.6 || ^8.7"
+    "typo3/cms-core": "^7.6 || ^8.7 || ^9.3"
   },
   "conflict": {
     "typo3-ter/naw-securedl": "*"

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -37,7 +37,7 @@ if ($configurationManager->getValue('apacheDelivery')) {
     }
 
 } else {
-    $TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_fe.php']['contentPostProc-output'][] = ':&' . 'Bitmotion\\SecureDownloads\\Service\\SecureDownloadService' . '->parseFE';
+    $TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_fe.php']['contentPostProc-output'][] = 'Bitmotion\\SecureDownloads\\Service\\SecureDownloadService' . '->parseFE';
 }
 
 $objectManager->registerImplementation('Bitmotion\\SecureDownloads\\Resource\\Publishing\\ResourcePublishingTarget',


### PR DESCRIPTION
This PR enables compatibility with TYPO3 v9.3.

Most functionalities work as expected, the BE-module throws one error in the JS-console.

`Uncaught TypeError: require is not a function
    at index.php?route=%2Fweb%2FSecureDownloadsTrafficlog%2F&token=bf868af0d6165fad889e5083fdd508ba1ce609ff&tx_securedownloads_web_securedownloadstrafficlog[action]=list&tx_securedownloads_web_securedownloadstrafficlog[controller]=Log:122`
