### PR TITLE
[BUGFIX] Consider cache_period from TypoScript settings

### DIFF
--- a/Classes/Request/RequestContext.php
+++ b/Classes/Request/RequestContext.php
@@ -109,8 +109,10 @@ class RequestContext
         /** @var TypoScriptFrontendController $typoScriptFrontendController */
         $typoScriptFrontendController = $GLOBALS['TSFE'];
 
-        if (isset($typoScriptFrontendController->page['cache_timeout'])) {
+        if (isset($typoScriptFrontendController->page['cache_timeout']) && $typoScriptFrontendController->page['cache_timeout'] > 0 ) {
             $this->cacheLifetime = (int)$typoScriptFrontendController->page['cache_timeout'];
+        } elseif (isset($typoScriptFrontendController->config['config']['cache_period'])) {
+            $this->cacheLifetime = (int)$typoScriptFrontendController->config['config']['cache_period'];
         } else {
             $this->cacheLifetime = 0;
         }


### PR DESCRIPTION
If the parameter config.cache_period ist longer than a day, the generated
links are invalid for the time between the link expiration date and
the expiration date of the page.

Considering the config.cache_period while calculating the cache_lifetime
solves the issue.