### PR TITLE
FEATURE: Add nginx x-accel-redirect fileDelivery mode

### DIFF
--- a/Classes/Resource/FileDelivery.php
+++ b/Classes/Resource/FileDelivery.php
@@ -350,6 +350,10 @@ class FileDelivery
                     fclose($handle);
                     break;
 
+                case 'x-accel-redirect':
+                    header('X-Accel-Redirect: '. $this->extensionConfiguration['protectedPath'] . $this->file);
+                    break;
+                    
                 case 'readfile':
                     //fallthrough, this is the default case
                 default:

--- a/Documentation/AdministratorManual/ExtensionManager/Index.rst
+++ b/Documentation/AdministratorManual/ExtensionManager/Index.rst
@@ -34,6 +34,7 @@ Properties
 	additionalMimeTypes_                 filedelivery                         string
 	outputFunction_                      filedelivery                         string
 	outputChunkSize_                     filedelivery                         integer
+	protectedPath_                       filedelivery                         string
 	log_                                 module                               boolean
 	debug_                               debug                                integer
 	==================================== ==================================== ==================
@@ -263,6 +264,21 @@ outputChunkSize
          Only applicable if you use readfile_chunked (see outputFunction). Specify the number of bytes, served as one chunk when delivering the file. Choosing this value too low is a performance killer.
    Default
          1048576
+
+.. _adminProtectedPath:
+
+protectedPath
+"""""""""""""""
+.. container:: table-row
+
+   Property
+         filedelivery.protectedPath
+   Data type
+         string
+   Description
+         Only applicable if you use x-accel-redirect (see outputFunction). Specify the protected path used in your nginx location directive;
+   Default
+         empty
 
 .. _adminLog:
 

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -41,12 +41,14 @@ forcedownloadtype = odt|pptx?|docx?|xlsx?|zip|rar|tgz|tar|gz
 # cat=filedelivery; type=string; label=additionalMimeTypes: Comma separated list of additional MIME types (file extension / mime type pairs, in which file extension and MIME type is separated by a pipe symbol). Can be used to override existing MIME type settings of the extension as well.
 additionalMimeTypes = txt|text/plain,html|text/html
 
-# cat=filedelivery; type=string; label = outputFunction:PHP function which is used to deliver the secured files (one of readfile, readfile_chunked, fpassthru)
+# cat=filedelivery; type=string; label = outputFunction:PHP function which is used to deliver the secured files (one of readfile, readfile_chunked, fpassthru, x-accel-redirect)
 outputFunction = readfile
 
 # cat=filedelivery; type=int; label = outputChunkSize: Size of chunks to be delivered in one go (only relevant if "readfile_chunked" is used) (default: 1048576 Bytes)
 outputChunkSize = 1048576
 
+# cat=filedelivery; type=string; label = protectedPath: Path to protected storage for nginx x-accel-redirect delivery method
+protectedPath =
 
 
 # cat=module; type=boolean; label = log:Log each file access


### PR DESCRIPTION
This PR adds the possibility to use nginx's X-Accel-Redirect for FileDelivery
A matching nginx `location` directive needs to be added.
The path to the protected directory is read from ext_ conf `protectedPath`

```
location /internal {
    internal;
    alias /path/to/your/protected/storage;
}
```